### PR TITLE
Prevent usage of relative imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ module.exports = {
   rules: {
     'no-console': 2,
     '@typescript-eslint/ban-ts-comment': 1,
-    '@typescript-eslint/no-unused-vars': 2
+    '@typescript-eslint/no-unused-vars': 2,
+    "import/no-relative-packages": 2,
+    "import/no-relative-parent-imports": 2
   }
 }


### PR DESCRIPTION
As most of our projects are NextJS based, we'd like to force absolute imports. If we ever use this package outside Next, it can be easily disabled.