### PR TITLE
Updated to omit parserOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ yarn add --dev @climatiq/eslint-config
 
 Now create an ESLint configuration file for your project that extends Climatiq's rules:
 
-```json
-{
-    "extends": ["@climatiq"]
+```js
+// eslint.rc.js
+module.exports = {
+    "extends": ["@climatiq"],
+    parserOptions: {
+        project: true,
+        tsconfigRootDir: __dirname,
+  },
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -25,11 +25,6 @@ module.exports = {
       { vars: 'all', varsIgnorePattern: '^_', args: 'after-used', argsIgnorePattern: '^_' },
     ],
   },
-
-  parserOptions: {
-    project: true,
-    tsconfigRootDir: "./tsconfig.json",
-  },
   overrides: [
     {
       files: ['**/*.test.ts', '**/*/test-stubs.ts', '**/*/test-helpers.ts'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@climatiq/eslint-config",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "ESlint configuration for Climatiq projects",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
It turns out that the previous eslint config works with eslint, but not with some of the stuff Vercel is doing when building. We can turn off the build lints, but I figured I'd try to fix it first.

This seems to be because the current `parserOptions` settings doesn't work because Vercel doesn't run commands as the root dir.

This PR removes the `parserOptions` from the shared config, and instructs to consumers to set it themselves - that way `__dirname` will resolve correctly. This seems to work, but I can't confirm until we've deployed and tested it.