### PR TITLE
Set unused-imports/no-unused-vars rule as an error type instead of warn

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ export default defineConfig([
       "@typescript-eslint/no-unused-vars": "off", // delegate to plugin below that handles both vars and imports
       "unused-imports/no-unused-imports": "error",
       "unused-imports/no-unused-vars": [
-        "warn",
+        "error",
         {
           vars: "all",
           varsIgnorePattern: "^_",

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ export default defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
-    ".vercel/**"
+    ".vercel/**",
+    ".claude/**"
   ])
 ]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@climatiq/eslint-config",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "ESlint configuration for Climatiq projects",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Coming from https://github.com/climatiq/dashboard-app/pull/911#discussion_r2764196554 and https://github.com/climatiq/dashboard-app/pull/911#discussion_r2764248383. It increases the error type to `error` for one of our rules and also adds the .claude folder in the ignores list
