### PR TITLE
chore(eslint): add clsx plugin to avoid unnecessary/incorrect clsx/cn usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 import prettier from "eslint-config-prettier/flat";
 import unusedImports from "eslint-plugin-unused-imports";
+import clsx from "eslint-plugin-clsx";
 import tseslint from "typescript-eslint";
-
 
 export default defineConfig([
   ...nextVitals,
@@ -28,8 +28,8 @@ export default defineConfig([
           "ts-check": "allow-with-description",
           "ts-expect-error": "allow-with-description",
           "ts-ignore": "allow-with-description",
-          "ts-nocheck": "allow-with-description"
-        }
+          "ts-nocheck": "allow-with-description",
+        },
       ],
       "@typescript-eslint/no-empty-function": "off",
       "@typescript-eslint/no-unused-vars": "off", // delegate to plugin below that handles both vars and imports
@@ -42,22 +42,34 @@ export default defineConfig([
           args: "after-used",
           argsIgnorePattern: "^_",
           caughtErrors: "all",
-          caughtErrorsIgnorePattern: "^_"
-        }
-      ]
-    }
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
   },
   {
     plugins: {
       // This plugin automatically removes unused imports
-      "unused-imports": unusedImports
-    }
+      "unused-imports": unusedImports,
+    },
+  },
+  {
+    plugins: { clsx },
+    settings: {
+      clsxOptions: {
+        clsx: ["default", "clsx"],
+        "@/src/lib/utils": ["cn"],
+      },
+    },
+    rules: {
+      ...clsx.configs.recommended.rules,
+    },
   },
   {
     files: ["**/*.tsx", "**/*.jsx"],
     rules: {
-      "no-console": "error" // Disable no-console rule for .tsx files
-    }
+      "no-console": "error", // Disable no-console rule for .tsx files
+    },
   },
   // Override default ignores of eslint-config-next.
   globalIgnores([
@@ -67,6 +79,6 @@ export default defineConfig([
     "build/**",
     "next-env.d.ts",
     ".vercel/**",
-    ".claude/**"
-  ])
+    ".claude/**",
+  ]),
 ]);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "^10.3.0",
     "eslint-config-next": "^16.2.5",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-clsx": "^0.1.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-unused-imports": "^4.3.0",
     "minimatch": ">=3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -588,6 +588,15 @@
     "@typescript-eslint/types" "^8.59.2"
     debug "^4.4.3"
 
+"@typescript-eslint/project-service@8.60.0":
+  version "8.60.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.60.0.tgz#b82ab12e64d005d0c7163d1240c432381f1bde0f"
+  integrity sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==
+  dependencies:
+    "@typescript-eslint/tsconfig-utils" "^8.60.0"
+    "@typescript-eslint/types" "^8.60.0"
+    debug "^4.4.3"
+
 "@typescript-eslint/scope-manager@8.59.2":
   version "8.59.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz#63cbd0af2e3180949d6be81122cc555bc71e736d"
@@ -596,10 +605,23 @@
     "@typescript-eslint/types" "8.59.2"
     "@typescript-eslint/visitor-keys" "8.59.2"
 
+"@typescript-eslint/scope-manager@8.60.0":
+  version "8.60.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz#7617a4617c043fe235dcf066f9a40f106cfd2fd5"
+  integrity sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==
+  dependencies:
+    "@typescript-eslint/types" "8.60.0"
+    "@typescript-eslint/visitor-keys" "8.60.0"
+
 "@typescript-eslint/tsconfig-utils@8.59.2", "@typescript-eslint/tsconfig-utils@^8.59.2":
   version "8.59.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz#6e92bc412083753185a79c9f1431e78169d9232f"
   integrity sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==
+
+"@typescript-eslint/tsconfig-utils@8.60.0", "@typescript-eslint/tsconfig-utils@^8.60.0":
+  version "8.60.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz#3af78c48956227a407dea9626b8db8ca53f130d2"
+  integrity sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==
 
 "@typescript-eslint/type-utils@8.59.2":
   version "8.59.2"
@@ -617,6 +639,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.59.2.tgz#01caabcd7e4715c33ad5e11cab260829714d6b9c"
   integrity sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==
 
+"@typescript-eslint/types@8.60.0", "@typescript-eslint/types@^8.58.0", "@typescript-eslint/types@^8.60.0":
+  version "8.60.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.60.0.tgz#e77ad768e933263b1960b2fe79de75fe1cc6e7db"
+  integrity sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==
+
 "@typescript-eslint/typescript-estree@8.59.2":
   version "8.59.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz#6a217ef65b18dbd12c718fc86a675d1d7a1414cc"
@@ -626,6 +653,21 @@
     "@typescript-eslint/tsconfig-utils" "8.59.2"
     "@typescript-eslint/types" "8.59.2"
     "@typescript-eslint/visitor-keys" "8.59.2"
+    debug "^4.4.3"
+    minimatch "^10.2.2"
+    semver "^7.7.3"
+    tinyglobby "^0.2.15"
+    ts-api-utils "^2.5.0"
+
+"@typescript-eslint/typescript-estree@8.60.0":
+  version "8.60.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz#c102196a44414481190041c99eea1d854e66001b"
+  integrity sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==
+  dependencies:
+    "@typescript-eslint/project-service" "8.60.0"
+    "@typescript-eslint/tsconfig-utils" "8.60.0"
+    "@typescript-eslint/types" "8.60.0"
+    "@typescript-eslint/visitor-keys" "8.60.0"
     debug "^4.4.3"
     minimatch "^10.2.2"
     semver "^7.7.3"
@@ -642,12 +684,30 @@
     "@typescript-eslint/types" "8.59.2"
     "@typescript-eslint/typescript-estree" "8.59.2"
 
+"@typescript-eslint/utils@^8.58.0":
+  version "8.60.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.60.0.tgz#6110cddaef87606ae4ca6f8bf81bb5949fc8e098"
+  integrity sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.9.1"
+    "@typescript-eslint/scope-manager" "8.60.0"
+    "@typescript-eslint/types" "8.60.0"
+    "@typescript-eslint/typescript-estree" "8.60.0"
+
 "@typescript-eslint/visitor-keys@8.59.2":
   version "8.59.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz#5ccc486913cd347883d69158836b1189a660bfe6"
   integrity sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==
   dependencies:
     "@typescript-eslint/types" "8.59.2"
+    eslint-visitor-keys "^5.0.0"
+
+"@typescript-eslint/visitor-keys@8.60.0":
+  version "8.60.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz#f2c41eedd3d7b03b808369fb2e3fb40a93783ec2"
+  integrity sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==
+  dependencies:
+    "@typescript-eslint/types" "8.60.0"
     eslint-visitor-keys "^5.0.0"
 
 "@unrs/resolver-binding-android-arm-eabi@1.11.1":
@@ -1258,6 +1318,16 @@ eslint-module-utils@^2.12.1:
   integrity sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==
   dependencies:
     debug "^3.2.7"
+
+eslint-plugin-clsx@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-clsx/-/eslint-plugin-clsx-0.1.0.tgz#0d8904312192b85c8a46eed62864271a4f93ff8e"
+  integrity sha512-g4Q3ybgXqFbyculk7OlkpSlP4ODSCwrZtEogWN49MMC3HcMYubl9b7L2Q3w3++43tMZAkQvQMzGkONDu1haJJg==
+  dependencies:
+    "@typescript-eslint/types" "^8.58.0"
+    "@typescript-eslint/utils" "^8.58.0"
+    esquery "^1.7.0"
+    remeda "^2.33.7"
 
 eslint-plugin-import@^2.32.0:
   version "2.32.0"
@@ -2310,6 +2380,11 @@ regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
     get-proto "^1.0.1"
     gopd "^1.2.0"
     set-function-name "^2.0.2"
+
+remeda@^2.33.7:
+  version "2.37.0"
+  resolved "https://registry.yarnpkg.com/remeda/-/remeda-2.37.0.tgz#91575e7acd11861aadb118f7356494bbfd1a9a4f"
+  integrity sha512-wN6BXWua0t4o7vDamqc27J3VRxnokG9cDezsFN2nOnt2JD/IkJQHTYqM6UvmEctAZETAoviwEFQZJO3kZ4Ohew==
 
 resolve-pkg-maps@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Adds the [clsx eslint plugin](https://github.com/temoncher/eslint-plugin-clsx) to make sure we don't use `cn` or `clsx` unnecessarily or in incorrect ways.

Example:

<img width="640" height="186" alt="8oQL1UKi4Yo" src="https://github.com/user-attachments/assets/2e50c0b6-8c70-4757-bed5-af8e66301933" />
